### PR TITLE
Refactor validation to async pool

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,10 @@
     "autoload": {
         "psr-4": {
             "App\\": "src/"
-        }
+        },
+        "files": [
+            "src/Support/async_polyfill.php"
+        ]
     },
     "scripts": {
         "validate": "php scripts/validate_emails.php",

--- a/config/app.php
+++ b/config/app.php
@@ -32,6 +32,9 @@ return [
         // Batch Processing settings
         'batch_size' => 100,
         'max_concurrent' => 10,
+        'async_chunk_size' => 100,
+        'async_timeout' => 30,
+        'async_sleep_time' => 50000,
         'memory_limit' => '512M',
         'max_execution_time' => 300
     ],

--- a/scripts/test_validator.php
+++ b/scripts/test_validator.php
@@ -62,12 +62,12 @@ echo "\n";
 
 echo "🔄 Starting standalone validation...\n\n";
 
-$results = [];
-foreach ($testEmails as $i => $email) {
-    echo "[" . ($i + 1) . "/" . count($testEmails) . sprintf('] Validating: %s ... ', $email);
+// Execute the entire sample set asynchronously instead of validating one email at a time.
+$results = $emailValidator->validateBatch($testEmails);
 
-    $result = $emailValidator->validate($email);
-    $results[] = $result;
+foreach ($results as $i => $result) {
+    $email = $result['email'];
+    echo "[" . ($i + 1) . "/" . count($results) . sprintf('] Validating: %s ... ', $email);
 
     if ($result['is_valid']) {
         echo "✅ VALID";

--- a/scripts/validate_emails.php
+++ b/scripts/validate_emails.php
@@ -94,11 +94,8 @@ do {
     // Extract email addresses
     $emailList = array_map(fn($email) => $email->email, $emails);
 
-    // Synchronous validation with advanced validator
-    $batchResults = [];
-    foreach ($emailList as $email) {
-        $batchResults[] = $emailValidator->validate($email);
-    }
+    // Run the batch through the async pool so validations execute concurrently.
+    $batchResults = $emailValidator->validateBatch($emailList);
 
     $stats = $emailValidator->getStats($batchResults);
 

--- a/scripts/validate_emails_safe.php
+++ b/scripts/validate_emails_safe.php
@@ -91,11 +91,8 @@ do {
     // Extract email addresses
     $emailList = array_map(fn($email) => $email->email, $emails);
 
-    // Synchronous validation (no async issues)
-    $batchResults = [];
-    foreach ($emailList as $email) {
-        $batchResults[] = $emailValidator->validate($email);
-    }
+    // Use the async pool to process each email concurrently while keeping the safe validator API.
+    $batchResults = $emailValidator->validateBatch($emailList);
 
     $stats = $emailValidator->getStats($batchResults);
 

--- a/scripts/validate_from_json.php
+++ b/scripts/validate_from_json.php
@@ -95,11 +95,8 @@ do {
     // Extract email addresses
     $emailList = array_map(fn($email) => $email->email, $emails);
 
-    // Synchronous validation with advanced validator
-    $batchResults = [];
-    foreach ($emailList as $email) {
-        $batchResults[] = $emailValidator->validate($email);
-    }
+    // Execute validations asynchronously so large JSON batches run concurrently.
+    $batchResults = $emailValidator->validateBatch($emailList);
 
     $stats = $emailValidator->getStats($batchResults);
 

--- a/src/ConfigManager.php
+++ b/src/ConfigManager.php
@@ -142,6 +142,18 @@ class ConfigManager
             $config['settings']['max_concurrent'] = (int)self::$env['MAX_CONCURRENT'];
         }
 
+        if (isset(self::$env['ASYNC_CHUNK_SIZE'])) {
+            $config['settings']['async_chunk_size'] = (int)self::$env['ASYNC_CHUNK_SIZE'];
+        }
+
+        if (isset(self::$env['ASYNC_TIMEOUT'])) {
+            $config['settings']['async_timeout'] = (int)self::$env['ASYNC_TIMEOUT'];
+        }
+
+        if (isset(self::$env['ASYNC_SLEEP_TIME'])) {
+            $config['settings']['async_sleep_time'] = (int)self::$env['ASYNC_SLEEP_TIME'];
+        }
+
         // Output configuration
         if (isset(self::$env['SAVE_RESULTS'])) {
             $config['save_results'] = filter_var(self::$env['SAVE_RESULTS'], FILTER_VALIDATE_BOOLEAN);

--- a/src/Support/Async/Pool.php
+++ b/src/Support/Async/Pool.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace App\Support\Async;
+
+use RuntimeException;
+use Throwable;
+
+class Pool
+{
+    private int $concurrency = 10;
+
+    private int $timeout = 60;
+
+    private int $sleepTime = 50000;
+
+    private int $taskCounter = 0;
+
+    /** @var array<int, Task> */
+    private array $queue = [];
+
+    /**
+     * @var array<int, array{task: Task, socket: resource, started_at: float}>
+     */
+    private array $running = [];
+
+    public static function create(): self
+    {
+        return new self();
+    }
+
+    public function concurrency(int $concurrency): self
+    {
+        $this->concurrency = max(1, $concurrency);
+
+        return $this;
+    }
+
+    public function timeout(int $seconds): self
+    {
+        $this->timeout = max(1, $seconds);
+
+        return $this;
+    }
+
+    public function sleepTime(int $microseconds): self
+    {
+        $this->sleepTime = max(1, $microseconds);
+
+        return $this;
+    }
+
+    public function add(callable $task): Task
+    {
+        $taskObject = new Task($task, $this->taskCounter++);
+        $this->queue[] = $taskObject;
+
+        return $taskObject;
+    }
+
+    public function wait(): void
+    {
+        if (!function_exists('pcntl_fork')) {
+            throw new RuntimeException('pcntl extension is required for async processing.');
+        }
+
+        while ($this->queue !== [] || $this->running !== []) {
+            $this->startPendingTasks();
+            $this->collectFinishedTasks();
+
+            if ($this->running !== []) {
+                usleep($this->sleepTime);
+            }
+        }
+    }
+
+    private function startPendingTasks(): void
+    {
+        while ($this->queue !== [] && count($this->running) < $this->concurrency) {
+            $task = array_shift($this->queue);
+            if (!$task instanceof Task) {
+                break;
+            }
+
+            $this->launchTask($task);
+        }
+    }
+
+    private function launchTask(Task $task): void
+    {
+        $sockets = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
+        if ($sockets === false) {
+            throw new RuntimeException('Failed to create socket pair for async task.');
+        }
+
+        [$parentSocket, $childSocket] = $sockets;
+
+        $pid = pcntl_fork();
+        if ($pid === -1) {
+            throw new RuntimeException('Failed to fork process for async task.');
+        }
+
+        if ($pid === 0) {
+            fclose($parentSocket);
+            $payload = $this->runTask($task);
+            fwrite($childSocket, $payload);
+            fclose($childSocket);
+            exit(0);
+        }
+
+        fclose($childSocket);
+        stream_set_blocking($parentSocket, false);
+
+        $this->running[$pid] = [
+            'task' => $task,
+            'socket' => $parentSocket,
+            'started_at' => microtime(true),
+        ];
+    }
+
+    private function runTask(Task $task): string
+    {
+        try {
+            $result = $task->execute();
+
+            return serialize(['status' => 'success', 'result' => $result]);
+        } catch (Throwable $throwable) {
+            return serialize(['status' => 'error', 'exception' => $throwable]);
+        }
+    }
+
+    private function collectFinishedTasks(): void
+    {
+        if ($this->running === []) {
+            return;
+        }
+
+        pcntl_signal_dispatch();
+
+        foreach ($this->running as $pid => $meta) {
+            $task = $meta['task'];
+            $socket = $meta['socket'];
+            $startedAt = $meta['started_at'];
+
+            $status = 0;
+            $waitResult = pcntl_waitpid($pid, $status, WNOHANG);
+            if ($waitResult === -1) {
+                fclose($socket);
+                unset($this->running[$pid]);
+                $task->triggerFailure(new RuntimeException('Failed to wait for async task.'));
+
+                continue;
+            }
+
+            if ($waitResult === 0) {
+                if ($this->timeout > 0 && (microtime(true) - $startedAt) >= $this->timeout) {
+                    $this->terminateTask($pid, $socket, $task, sprintf(
+                        'Async task exceeded timeout of %d seconds.',
+                        $this->timeout
+                    ));
+                }
+
+                continue;
+            }
+
+            $payload = stream_get_contents($socket);
+            fclose($socket);
+            unset($this->running[$pid]);
+
+            if ($payload === false || $payload === '') {
+                $task->triggerFailure(new RuntimeException('Async task returned an empty result.'));
+
+                continue;
+            }
+
+            $this->handlePayload($task, $payload);
+        }
+    }
+
+    private function terminateTask(int $pid, $socket, Task $task, string $message): void
+    {
+        if (function_exists('posix_kill')) {
+            @posix_kill($pid, SIGKILL);
+        }
+
+        $status = 0;
+        pcntl_waitpid($pid, $status);
+        fclose($socket);
+        unset($this->running[$pid]);
+
+        $task->triggerFailure(new RuntimeException($message));
+    }
+
+    private function handlePayload(Task $task, string $payload): void
+    {
+        $data = @unserialize($payload);
+        if (!is_array($data) || !isset($data['status'])) {
+            $task->triggerFailure(new RuntimeException('Invalid async payload received.'));
+
+            return;
+        }
+
+        if ($data['status'] === 'success') {
+            $task->triggerSuccess($data['result'] ?? null);
+
+            return;
+        }
+
+        $exception = $data['exception'] ?? null;
+        if ($exception instanceof Throwable) {
+            $task->triggerFailure($exception);
+
+            return;
+        }
+
+        $task->triggerFailure(new RuntimeException('Async task failed with an unknown error.'));
+    }
+}

--- a/src/Support/Async/Task.php
+++ b/src/Support/Async/Task.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Support\Async;
+
+use Throwable;
+
+class Task
+{
+    /** @var callable */
+    private $callback;
+
+    /** @var callable|null */
+    private $thenCallback = null;
+
+    /** @var callable|null */
+    private $catchCallback = null;
+
+    private int $id;
+
+    public function __construct(callable $callback, int $id)
+    {
+        $this->callback = $callback;
+        $this->id = $id;
+    }
+
+    public function then(callable $callback): self
+    {
+        $this->thenCallback = $callback;
+
+        return $this;
+    }
+
+    public function catch(callable $callback): self
+    {
+        $this->catchCallback = $callback;
+
+        return $this;
+    }
+
+    public function execute(): mixed
+    {
+        $callback = $this->callback;
+
+        return $callback();
+    }
+
+    public function triggerSuccess(mixed $result): void
+    {
+        if ($this->thenCallback !== null) {
+            ($this->thenCallback)($result);
+        }
+    }
+
+    public function triggerFailure(Throwable $throwable): void
+    {
+        if ($this->catchCallback !== null) {
+            ($this->catchCallback)($throwable);
+
+            return;
+        }
+
+        throw $throwable;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+}

--- a/src/Support/async_polyfill.php
+++ b/src/Support/async_polyfill.php
@@ -1,0 +1,12 @@
+<?php
+
+use App\Support\Async\Pool as AppAsyncPool;
+use App\Support\Async\Task as AppAsyncTask;
+
+if (!class_exists(\Spatie\Async\Pool::class)) {
+    class_alias(AppAsyncPool::class, \Spatie\Async\Pool::class);
+}
+
+if (!class_exists(\Spatie\Async\Task::class)) {
+    class_alias(AppAsyncTask::class, \Spatie\Async\Task::class);
+}


### PR DESCRIPTION
## Summary
- add an async pooling layer (with a fallback implementation) so batch validation runs concurrently
- refactor the email, SMTP, and local SMTP validators plus CLI scripts to leverage the async pool with graceful error handling
- extend configuration to support async tuning options and keep the public API stable

## Testing
- composer dump-autoload
- php -l src/EmailValidator.php
- php -l src/SMTPValidator.php
- php -l src/LocalSMTPValidator.php
- php -l src/Support/Async/Pool.php
- php -l src/Support/Async/Task.php
- php -l scripts/validate_emails.php
- php -l scripts/validate_emails_safe.php
- php -l scripts/validate_from_json.php
- php -l scripts/test_validator.php

------
https://chatgpt.com/codex/tasks/task_e_68cd1fcfc6cc8331a49f8cc7433dc8b5