### PR TITLE
Allow local SMTP positives to bypass heuristics

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -25,7 +25,8 @@ return [
         'local_smtp_validation' => true, // Enable local SMTP validation
         'local_smtp_host' => 'localhost',
         'local_smtp_port' => 1025,
-        
+        'enable_local_email_patterns' => false,
+
         'from_email' => 'test@example.com',
         'from_name' => 'Email Validator',
         

--- a/scripts/test_validator.php
+++ b/scripts/test_validator.php
@@ -16,6 +16,7 @@ $config = ConfigManager::load();
 $config['settings']['use_advanced_validation'] = true;
 $config['settings']['use_strict_rfc'] = false;
 $config['settings']['local_smtp_validation'] = true;
+$config['settings']['enable_local_email_patterns'] = false; // Ensure heuristics are disabled for baseline test
 
 $emailValidator = new EmailValidator($config['settings']);
 
@@ -51,6 +52,7 @@ echo "📊 Configuration:\n";
 echo "  - Advanced validation: " . ($config['settings']['use_advanced_validation'] ? "YES" : "NO") . "\n";
 echo "  - Strict RFC: " . ($config['settings']['use_strict_rfc'] ? "YES" : "NO") . "\n";
 echo "  - Local SMTP: " . ($config['settings']['local_smtp_validation'] ? "YES" : "NO") . "\n";
+echo "  - Local heuristics: " . ($config['settings']['enable_local_email_patterns'] ? "YES" : "NO") . "\n";
 echo "  - Total test emails: " . count($testEmails) . "\n\n";
 
 echo "📧 Test emails:\n";

--- a/src/ConfigManager.php
+++ b/src/ConfigManager.php
@@ -133,6 +133,14 @@ class ConfigManager
             $config['settings']['local_smtp_port'] = (int)self::$env['LOCAL_SMTP_PORT'];
         }
 
+        if (isset(self::$env['ENABLE_LOCAL_EMAIL_PATTERNS'])) {
+            $config['settings']['enable_local_email_patterns'] = filter_var(
+                self::$env['ENABLE_LOCAL_EMAIL_PATTERNS'],
+                FILTER_VALIDATE_BOOLEAN,
+                FILTER_NULL_ON_FAILURE
+            ) ?? false;
+        }
+
         // Batch processing configuration
         if (isset(self::$env['BATCH_SIZE'])) {
             $config['settings']['batch_size'] = (int)self::$env['BATCH_SIZE'];

--- a/src/EmailValidator.php
+++ b/src/EmailValidator.php
@@ -44,6 +44,7 @@ class EmailValidator
             'local_smtp_validation' => false,
             'local_smtp_host' => 'localhost',
             'local_smtp_port' => 1025,
+            'enable_local_email_patterns' => false,
             'use_advanced_validation' => true,
             'use_strict_rfc' => false,
             'max_concurrent' => 10,
@@ -72,7 +73,8 @@ class EmailValidator
                 'smtp_host' => $this->config['local_smtp_host'],
                 'smtp_port' => $this->config['local_smtp_port'],
                 'from_email' => $this->config['from_email'],
-                'from_name' => $this->config['from_name']
+                'from_name' => $this->config['from_name'],
+                'enable_local_email_patterns' => $this->config['enable_local_email_patterns'] ?? false,
             ]);
         }
 


### PR DESCRIPTION
## Summary
- ensure local SMTP validation treats 2xx RCPT replies as valid unless pattern heuristics are explicitly enabled
- add the new `enable_local_email_patterns` toggle to the shared configuration defaults and environment loader
- document the heuristic toggle in the sample validator script so baseline runs expect accepted addresses to pass

## Testing
- php -l src/LocalSMTPValidator.php
- php -l src/EmailValidator.php
- php -l config/app.php
- php -l src/ConfigManager.php
- php -l scripts/test_validator.php
- composer test *(fails: requires dependencies that need a GitHub token to install)*

------
https://chatgpt.com/codex/tasks/task_e_68cd3a27cf1883319890994ddc6ef5d3