### PR TITLE
Add A-record fallback to local SMTP domain validation

### DIFF
--- a/example_emails.json
+++ b/example_emails.json
@@ -3,6 +3,7 @@
   "contact@yahoo.com",
   "info@outlook.com",
   "test@example.com",
+  "admin@iana.org",
   "invalid-email",
   "user@",
   "@domain.com",

--- a/scripts/test_validator.php
+++ b/scripts/test_validator.php
@@ -25,6 +25,7 @@ $testEmails = [
     'contact@yahoo.com',
     'info@outlook.com',
     'test@example.com',
+    'admin@iana.org', // Valid domain with only A record (no MX)
 
     // Invalid emails
     'invalid-email',

--- a/src/EmailValidator.php
+++ b/src/EmailValidator.php
@@ -72,8 +72,10 @@ class EmailValidator
                 'smtp_host' => $this->config['local_smtp_host'],
                 'smtp_port' => $this->config['local_smtp_port'],
                 'from_email' => $this->config['from_email'],
-                'from_name' => $this->config['from_name']
-            ]);
+                'from_name' => $this->config['from_name'],
+                'check_mx' => $this->config['check_mx'],
+                'check_a' => $this->config['check_a'],
+            ], $this->dnsValidator);
         }
 
         $this->asyncConcurrency = max(1, (int)($this->config['max_concurrent'] ?? 10));


### PR DESCRIPTION
## Summary
- reuse the DNSValidator inside the local SMTP validator so it recognises MX and A record domain checks consistently with the main validator
- pass DNS configuration from the main EmailValidator and fall back to manual A record lookups when MX records are missing
- extend the local SMTP sample data to cover domains that only expose A records

## Testing
- `composer test` *(fails: missing vendor autoloader; installing dependencies requires GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd3a2de1808331a5cd5f2b934c25f8